### PR TITLE
Add macros

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,9 @@ mod client;
 pub mod credentials;
 mod object_type;
 mod types;
+
+#[macro_use]
+mod macros;
 pub mod vm;
 
 pub use client::{Client, RestartError, RevertSnapshotError};

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,33 @@
+#[macro_export]
+macro_rules! procedure_args {
+    ($($key:expr => $value:expr,)+) => (procedure_args!($($key => $value),+));
+
+    ($($key:expr => $value:expr),*) => {
+        {
+            #[allow(unused_mut)]
+            let mut map = ::std::collections::BTreeMap::new();
+            $(
+                let _ = map.insert($key, serde_json::Value::from($value));
+            )*
+            map
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! procedure_object {
+    ($($key:expr => $value:expr,)+) => (procedure_args!($($key => $value),+));
+
+    ($($key:literal => $value:expr),*) => (procedure_object!($(String::from($key) => $value),+));
+
+    ($($key:expr => $value:expr),*) => {
+        {
+            #[allow(unused_mut)]
+            let mut map = ::serde_json::Map::new();
+            $(
+                let _ = map.insert($key, serde_json::Value::from($value));
+            )*
+            map
+        }
+    };
+}

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -7,6 +7,8 @@ use crate::VmId;
 /// Note that the "other" property contains a lot of different data. In the Xen Orchestra the user may
 /// even add additional values. For this reason the struct is made generic over the type `O`.
 /// See the trait [`OtherInfo`] for more info
+///
+/// Also see https://github.com/vatesfr/xen-orchestra/blob/a505cd9567233aab7ca6488b2fb8a0b6c610fa08/packages/xo-server/src/xapi-object-to-xo.mjs#L273
 #[derive(serde::Deserialize, Debug)]
 pub struct Vm<O> {
     pub id: VmId,


### PR DESCRIPTION
Add procedure_args! and procedure_object! to make it easier to specify arguments to rpc procedures. Also add internal macros to reduce boilderplate.

This PR also changes both `filter` and `limit` arguments for `get_vms` and `get_snapshots` to be impl Into<Option<_>> instead of `Option<_>` which might cause some inference errors.