### PR TITLE
impl Hash for id types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xo-api-client"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Albin Hedman <albin9604@gmail.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/xo-api-client.svg)](https://crates.io/crates/xo-api-client)
 [![docs.rs](https://docs.rs/xo-api-client/badge.svg)](https://docs.rs/xo-api-client/)
-[![dependency status](https://deps.rs/crate/xo-api-client/0.1.0/status.svg)](https://deps.rs/crate/xo-api-client/0.1.0)
+[![dependency status](https://deps.rs/crate/xo-api-client/0.1.1/status.svg)](https://deps.rs/crate/xo-api-client/0.1.1)
 
 <!--
 TODO: Add tests before showing these badges

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -14,6 +14,12 @@ impl ToString for Token {
     }
 }
 
+impl From<String> for Token {
+    fn from(s: String) -> Self {
+        Token(s)
+    }
+}
+
 impl FromStr for Token {
     type Err = Impossible;
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -95,7 +95,7 @@ macro_rules! declare_id_type {
         $v:vis struct $t:ident;
     ) => {
         $(#[$meta])*
-        #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
+        #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize, Hash)]
         #[serde(transparent)]
         $v struct $t(pub(crate) String);
 


### PR DESCRIPTION
implement `Hash` for id types like `VmId` and similar. This is required for using id types as key in `HashMap`s.

implement `From<String>` for `Token`.